### PR TITLE
Fixed new discussion button for no results.

### DIFF
--- a/src/Views/blocks/search-empty.blade.php
+++ b/src/Views/blocks/search-empty.blade.php
@@ -1,7 +1,14 @@
 <div class="no-results px-3 py-3 px-sm-5 py-sm-5 d-flex flex-column align-items-center justify-content-center">
     <h4 class="font-weight-black mb-2">No discussion found...</h4>
-    <p class="lead mb-4">We couldn't find results for the search <strong>{{ $query }}</strong>.</p>
+    <p class="lead mb-4">
+        We couldn't find results for the search <b><i>"{{ $query }}"</i></b>.
+    </p>
+    @if (auth()->check())
+    <button class="btn btn-primary new_discussion_btn">
+        <i class="fal fa-comment-alt"></i> Start A New Discussion</button>
+    @else
     <a class="btn btn-primary" href="{{ route('login', ['redirect_to' => url()->current()]) }}">
-        <i class="fal fa-comment-alt"></i> Start A New Discussion
+        <i class="fal fa-comment-alt"></i> Login To Start A New Discussion
     </a>
+    @endif
 </div>

--- a/src/Views/discussion.blade.php
+++ b/src/Views/discussion.blade.php
@@ -65,7 +65,7 @@
                 <div class="col-md-3 left-column">
                     <!-- SIDEBAR -->
                     <div class="chatter_sidebar">
-                        <button class="btn btn-primary" id="new_discussion_btn"><i class="chatter-new"></i> @lang('chatter::messages.discussion.new')</button>
+                        <button class="btn btn-primary new_discussion_btn"><i class="chatter-new"></i> @lang('chatter::messages.discussion.new')</button>
                         <a href="{{ route('chatter.home') }}"><i class="chatter-bubble"></i> @lang('chatter::messages.discussion.all')</a>
                         <ul class="nav nav-pills nav-stacked">
                             <?php $categories = DevDojo\Chatter\Models\Models::category()->all(); ?>
@@ -420,7 +420,7 @@
             $('.chatter-close, #cancel_discussion').click(function(){
                 $('#new_discussion_in_discussion_view').slideUp();
             });
-            $('#new_discussion_btn').click(function(){
+            $('.new_discussion_btn').click(function(){
                 @if(Auth::guest())
                     window.location.href = "{{ route('chatter.login') }}";
                 @else

--- a/src/Views/home.blade.php
+++ b/src/Views/home.blade.php
@@ -64,7 +64,7 @@
             <div class="col-md-3 left-column">
                 <!-- SIDEBAR -->
                 <div class="chatter_sidebar">
-                    <button class="btn btn-primary" id="new_discussion_btn"><i class="chatter-new"></i> @lang('chatter::messages.discussion.new')</button>
+                    <button class="btn btn-primary new_discussion_button"><i class="chatter-new"></i> @lang('chatter::messages.discussion.new')</button>
                     <a href="{{ route('chatter.home') }}"><i class="chatter-bubble"></i> @lang('chatter::messages.discussion.all')</a>
                     {!! $categoriesMenu !!}
                 </div>
@@ -211,7 +211,8 @@
         $('.chatter-close, #cancel_discussion').click(function(){
             $('#new_discussion').slideUp();
         });
-        $('#new_discussion_btn').click(function(){
+
+        $('.new_discussion_btn').click(function(){
             @if(Auth::guest())
                 window.location.href = "{{ route('login') }}";
             @else


### PR DESCRIPTION
There is a bug where when you search a forum and get no results, the new discussion button wouldn't work. In order to get this to work, the js that powers that button has to support multiple buttons on the page. Before it was powered by the id "new_discussion_btn". I changes this to a class "new_discussion_btn" and updated all references.

A MNM pull request will be added to accomodate the vendor view files.